### PR TITLE
Add Redux toggle tests

### DIFF
--- a/src/app/store.test.js
+++ b/src/app/store.test.js
@@ -1,0 +1,27 @@
+import { store, toggleTabKeyForLap, toggleTabKeyForOth, toggleTabKeyForMob } from './store';
+
+describe('tab key toggle reducers', () => {
+  test('toggleTabKeyForLap toggles between "hidden" and ""', () => {
+    expect(store.getState().tabKeyForLap).toBe('hidden');
+    store.dispatch(toggleTabKeyForLap());
+    expect(store.getState().tabKeyForLap).toBe('');
+    store.dispatch(toggleTabKeyForLap());
+    expect(store.getState().tabKeyForLap).toBe('hidden');
+  });
+
+  test('toggleTabKeyForOth toggles between "hidden" and ""', () => {
+    expect(store.getState().tabKeyForOth).toBe('hidden');
+    store.dispatch(toggleTabKeyForOth());
+    expect(store.getState().tabKeyForOth).toBe('');
+    store.dispatch(toggleTabKeyForOth());
+    expect(store.getState().tabKeyForOth).toBe('hidden');
+  });
+
+  test('toggleTabKeyForMob toggles between "hidden" and ""', () => {
+    expect(store.getState().tabKeyForMob).toBe('hidden');
+    store.dispatch(toggleTabKeyForMob());
+    expect(store.getState().tabKeyForMob).toBe('');
+    store.dispatch(toggleTabKeyForMob());
+    expect(store.getState().tabKeyForMob).toBe('hidden');
+  });
+});


### PR DESCRIPTION
## Summary
- add a Jest test file for Redux store toggles
- verify toggles for laptop, other and mobile sections

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a198ee8bc832d8cbeb42ed5a4aeec